### PR TITLE
fixed repeating seed issue

### DIFF
--- a/cmake/Packages/CFITSIO.cmake
+++ b/cmake/Packages/CFITSIO.cmake
@@ -19,7 +19,7 @@ IF (NOT CFITSIO_FOUND)
 
   # Search user environment for headers, then default paths; extract version
   FIND_PATH (CFITSIO_INCLUDE_DIR fitsio.h
-    PATHS $ENV{CFITSIOROOT}/include
+    PATHS $ENV{CFITSIOROOT}/include /n/holylfs05/LABS/arguelles_delgado_lab/Everyone/pzhelnin/DiMuons/local/include
     NO_DEFAULT_PATH)
   FIND_PATH (CFITSIO_INCLUDE_DIR fitsio.h)
   if(CFITSIO_INCLUDE_DIR)
@@ -40,7 +40,7 @@ IF (NOT CFITSIO_FOUND)
 
   # Search user environment for libraries, then default paths
   FIND_LIBRARY (CFITSIO_LIBRARIES NAMES cfitsio
-    PATHS $ENV{CFITSIOROOT}/lib
+    PATHS $ENV{CFITSIOROOT}/lib /n/holylfs05/LABS/arguelles_delgado_lab/Everyone/pzhelnin/DiMuons/local/lib
     NO_DEFAULT_PATH)
   FIND_LIBRARY (CFITSIO_LIBRARIES NAMES cfitsio)
   GET_FILENAME_COMPONENT (CFITSIO_LIB_DIR ${CFITSIO_LIBRARIES} PATH)

--- a/projects/injection/public/SIREN/injection/Weighter.tcc
+++ b/projects/injection/public/SIREN/injection/Weighter.tcc
@@ -121,12 +121,9 @@ double ProcessWeighter<ProcessType>::InteractionProbability(std::tuple<siren::ma
         std::vector<std::shared_ptr<siren::interactions::CrossSection>> const & xs_list = target_xs.second;
         double total_xs = 0.0;
         for(auto const & xs : xs_list) {
-            std::vector<siren::dataclasses::InteractionSignature> signatures = xs->GetPossibleSignaturesFromParents(record.signature.primary_type, target_xs.first);
-            for(auto const & signature : signatures) {
-                fake_record.signature = signature;
-                // Add total cross section
-                total_xs += xs->TotalCrossSection(fake_record);
-            }
+            fake_record.signature.primary_type = record.signature.primary_type;
+            fake_record.signature.target_type = target_xs.first;
+            total_xs += xs->TotalCrossSectionAllFinalStates(fake_record);
         }
         total_cross_sections.push_back(total_xs);
     }
@@ -172,12 +169,9 @@ double ProcessWeighter<ProcessType>::NormalizedPositionProbability(std::tuple<si
         std::vector<std::shared_ptr<siren::interactions::CrossSection>> const & xs_list = target_xs.second;
         double total_xs = 0.0;
         for(auto const & xs : xs_list) {
-            std::vector<siren::dataclasses::InteractionSignature> signatures = xs->GetPossibleSignaturesFromParents(record.signature.primary_type, target_xs.first);
-            for(auto const & signature : signatures) {
-                fake_record.signature = signature;
-                // Add total cross section
-                total_xs += xs->TotalCrossSection(fake_record);
-            }
+            fake_record.signature.primary_type = record.signature.primary_type;
+            fake_record.signature.target_type = target_xs.first;
+            total_xs += xs->TotalCrossSectionAllFinalStates(fake_record);
         }
         total_cross_sections.push_back(total_xs);
     }

--- a/projects/interactions/CMakeLists.txt
+++ b/projects/interactions/CMakeLists.txt
@@ -22,6 +22,7 @@ LIST (APPEND interactions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/CharmMesonDecay.cxx
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/DMesonELoss.cxx
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/QuarkDISFromSpline.cxx
+    ${PROJECT_SOURCE_DIR}/projects/interactions/private/PythiaDISCrossSection.cxx
 
 )
 add_library(SIREN_interactions OBJECT ${interactions_SOURCES})
@@ -30,6 +31,15 @@ target_include_directories(SIREN_interactions PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/projects/interactions/public/>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/SIREN/interactions/>
     ${PYTHON_INCLUDE_DIRS}
+)
+
+# Pythia8 and LHAPDF for PythiaDISCrossSection
+set(PYTHIA8_DIR "/n/holylfs05/LABS/arguelles_delgado_lab/Everyone/pzhelnin/PYTHIA/install_gcc13")
+set(LHAPDF_DIR "/n/holylfs05/LABS/arguelles_delgado_lab/Everyone/pzhelnin/LHAPDF/new_install")
+
+target_include_directories(SIREN_interactions PUBLIC
+    ${PYTHIA8_DIR}/include
+    ${LHAPDF_DIR}/include
 )
 
 target_link_libraries(SIREN_interactions
@@ -45,6 +55,9 @@ target_link_libraries(SIREN_interactions
         SIREN_detector
 )
 
+target_link_directories(SIREN_interactions PUBLIC ${PYTHIA8_DIR}/lib ${LHAPDF_DIR}/lib)
+target_link_libraries(SIREN_interactions PUBLIC pythia8 LHAPDF)
+
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/projects/interactions/public/"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING
@@ -57,7 +70,8 @@ package_add_test(UnitTest_DipoleFromTable ${PROJECT_SOURCE_DIR}/projects/interac
 #package_add_test(UnitTest_ElasticScattering ${PROJECT_SOURCE_DIR}/projects/interactions/private/test/ElasticScattering_TEST.cxx)
 
 pybind11_add_module(interactions ${PROJECT_SOURCE_DIR}/projects/interactions/private/pybindings/interactions.cxx)
-target_link_libraries(interactions PRIVATE SIREN photospline rk_static pybind11::embed)
+target_link_libraries(interactions PRIVATE SIREN photospline rk_static pybind11::embed pythia8 LHAPDF)
+target_link_directories(interactions PRIVATE ${PYTHIA8_DIR}/lib ${LHAPDF_DIR}/lib)
 #pybind11_add_module(pyDarkNewsSerializer ${PROJECT_SOURCE_DIR}/projects/interactions/private/pybindings/pyDarkNewsSerializer.cxx)
 #target_link_libraries(pyDarkNewsSerializer PRIVATE SIREN photospline rk_static pybind11::embed)
 if(DEFINED SKBUILD)

--- a/projects/interactions/private/CharmDISFromSpline.cxx
+++ b/projects/interactions/private/CharmDISFromSpline.cxx
@@ -472,7 +472,7 @@ void CharmDISFromSpline::SampleFinalState(dataclasses::CrossSectionDistributionR
     // kin_vars and its twin are 3-vectors containing [nu-energy, Bjorken X, Bjorken Y]
     std::array<double,3> kin_vars, test_kin_vars;
 
-    // centers of the cross section spline tales.
+    // centers of the cross section spline tables.
     std::array<int,3> spline_table_center, test_spline_table_center;
 
     // values of cross_section from the splines.  By * Bx * Spline(E,x,y)

--- a/projects/interactions/private/CharmMesonDecay.cxx
+++ b/projects/interactions/private/CharmMesonDecay.cxx
@@ -156,13 +156,16 @@ double CharmMesonDecay::TotalDecayWidthForFinalState(dataclasses::InteractionRec
     std::set<siren::dataclasses::Particle::ParticleType> hadrons = {siren::dataclasses::Particle::ParticleType::Hadrons};                                                                        
     if (primary == siren::dataclasses::Particle::ParticleType::DPlus) {
       tau = 1040 * (1e-15);
+      // if (secondaries == k0_eplus_nue) {branching_ratio = .1607;} // e+ semileptonic mode according to pdg
+      // else if (secondaries == k0_muplus_numu) {branching_ratio = .176;} // mu+ anything according to pdg
+      // else if (secondaries == hadrons) {branching_ratio = (1 - .1607 - .176);} // everything else
       if (secondaries == k0_eplus_nue) {branching_ratio = .1607;} // e+ semileptonic mode according to pdg
-      else if (secondaries == k0_muplus_numu) {branching_ratio = .176;} // mu+ anything according to pdg
+      else if (secondaries == k0_muplus_numu) {branching_ratio = .176;} // mu+ anything according to pdg (K + K* combined)
       else if (secondaries == hadrons) {branching_ratio = (1 - .1607 - .176);} // everything else
     } else if (primary == siren::dataclasses::Particle::ParticleType::D0) {
       tau = 410.1 * (1e-15);
       if (secondaries == kminus_eplus_nue) {branching_ratio = .0649;} // e+ semileptonic mode according to pdg
-      else if (secondaries == kminus_muplus_numu) {branching_ratio = .067;} // mu+ anything according to pdg
+      else if (secondaries == kminus_muplus_numu) {branching_ratio = .067;} // mu+ anything according to pdg (K + K* combined)
       else if (secondaries == hadrons) {branching_ratio = (1 - .0649 - .067);} // everything else
     }
     else {
@@ -211,6 +214,7 @@ std::vector<dataclasses::InteractionSignature> CharmMesonDecay::GetPossibleSigna
       semilep_signature.secondary_types[0] = siren::dataclasses::Particle::ParticleType::KMinus;
       semilep_signature.secondary_types[1] = siren::dataclasses::Particle::ParticleType::EPlus;
       semilep_signature.secondary_types[2] = siren::dataclasses::Particle::ParticleType::NuE;
+      
       signatures.push_back(semilep_signature);
       semilep_signature.secondary_types[0] = siren::dataclasses::Particle::ParticleType::KMinus;
       semilep_signature.secondary_types[1] = siren::dataclasses::Particle::ParticleType::MuPlus;
@@ -267,8 +271,10 @@ double CharmMesonDecay::DifferentialDecayWidth(std::vector<double> constants, do
     double ms = constants[2];
     double Q2tilde = Q2 / ms;
     // compute the 3-momentum as a function of Q2
-    double EK = 0.5 * (Q2 - pow(mD, 2 + pow(mK, 2))) / mD; // energy of Kaon
-    double PK = pow(pow(EK, 2) - pow(mK, 2), 1/2);
+    double EK = 0.5 * (pow(mD, 2) + pow(mK, 2) - Q2) / mD; // energy of Kaon
+    double PK2 = pow(EK, 2) - pow(mK, 2);
+    if (PK2 <= 0) return 0.0; // below kinematic threshold
+    double PK = sqrt(PK2);
     // plug in the constants
     double dGamma = pow(siren::utilities::Constants::FermiConstant,2) / (24 * pow(siren::utilities::Constants::pi,3)) * pow(F0CKM,2) *
                     pow((1/((1-Q2tilde) * (1 - alpha * Q2tilde))),2) * pow(PK,3);
@@ -350,82 +356,137 @@ void CharmMesonDecay::SampleFinalStateHadronic(dataclasses::CrossSectionDistribu
 }
 
 void CharmMesonDecay::SampleFinalState(dataclasses::CrossSectionDistributionRecord & record, std::shared_ptr<siren::utilities::SIREN_random> random) const {
-    // first handle hadronic decay separately, in the end we want to handle all decays in separate functions
+    // first handle hadronic decay separately
     dataclasses::InteractionSignature signature = record.signature;
     if (signature.secondary_types[0] == siren::dataclasses::Particle::ParticleType::Hadrons) {
       SampleFinalStateHadronic(record, random);
       return;
     }
-    // first obtain the constants needed for further computation from the signature
-    std::vector<double> constants = FormFactorFromRecord(record);
-    double mD = particleMass(record.signature.primary_type);
-    double mK = particleMass(record.signature.secondary_types[0]);
 
-    // first sample a q^2
-    double rand_value_for_Q2 = random->Uniform(0, 1);
-    double Q2 = inverseCdf(rand_value_for_Q2);
-    
-    // now sample isotropically the "zenith" direction
-    double cosTheta = random->Uniform(-1, 1);
-    double sinTheta = std::sin(std::acos(cosTheta));
-      // set the x axis to be the D direction
+    // =========================================================================
+    // 3-body phase space sampling following Pythia's approach
+    // (ParticleDecays::threeBody in ParticleDecays.cc)
+    //
+    // D (m0) -> K (m1) + lepton (m2) + neutrino (m3)
+    //
+    // Phase space: sample m23 (lepton-neutrino invariant mass = sqrt(q^2))
+    // flat in allowed range, accept-reject on phase space weight.
+    // Then apply V-A matrix element correction.
+    // =========================================================================
+
+    double mD = particleMass(record.signature.primary_type);     // m0
+    double mK_base = particleMass(record.signature.secondary_types[0]); // m1 (K mass from signature)
+    double ml = particleMass(record.signature.secondary_types[1]); // m2
+    double mnu = 0.0;                                              // m3
+
+    // Randomly choose between D->K l nu and D->K* l nu channels
+    // based on their relative branching ratios within the muonic mode.
+    // Pythia uses the same V-A matrix element (meMode=22) for both;
+    // only the hadron mass differs: K(494 MeV) vs K*(892 MeV).
+    double mKstar = 0.89166;  // K*(892) mass in GeV
+    double fracK;  // fraction of events that are D->K (vs D->K*)
+    if (record.signature.primary_type == siren::dataclasses::Particle::ParticleType::DPlus) {
+        // D+ -> K0bar mu+ nu: BR=8.74%, D+ -> K*0bar mu+ nu: BR=5.33%
+        fracK = 8.74 / (8.74 + 5.33);  // ~0.621
+    } else {
+        // D0 -> K- mu+ nu: BR=3.41%, D0 -> K*- mu+ nu: BR=2.17%
+        fracK = 3.41 / (3.41 + 2.17);  // ~0.611
+    }
+    double mK = (random->Uniform(0, 1) < fracK) ? mK_base : mKstar;
+
+    // D meson 4-momentum in lab frame
+    rk::P4 p4D_lab(geom3::Vector3(record.primary_momentum[1],
+                                    record.primary_momentum[2],
+                                    record.primary_momentum[3]),
+                    record.primary_mass);
     geom3::UnitVector3 x_dir = geom3::UnitVector3::xAxis();
-      //set the D direction in lab frame and compute its angle wrt the x axis
-    rk::P4 p4D_lab(geom3::Vector3(record.primary_momentum[1], record.primary_momentum[2], record.primary_momentum[3]), record.primary_mass);
-    geom3::Vector3 p3D_lab = p4D_lab.momentum();
-    geom3::UnitVector3 p3D_lab_dir = p3D_lab.direction();
-    geom3::Rotation3 x_to_p3D_lab_rot = geom3::rotationBetween(x_dir, p3D_lab_dir);
-    // compute the momentum magnitude of the W and the K/pi
-    double EK = 0.5 * (pow(mD, 2) + pow(mK, 2) - Q2) / mD; // energy of Kaon
-    double PK = pow(pow(EK, 2) - pow(mK, 2), .5); // momentum magnitude of kaon in D rest frame
-    double PW = sqrt(Q2); // momentum magnitude of virtual W in D rest frame
-    // compute the 3 vectors of the W and the K/pi in the D rest frame, defined wrt x axis
-    rk::P4 p4K_Drest(PK * geom3::Vector3(cosTheta, sinTheta, 0), mK);
-    rk::P4 p4W_Drest(PK * geom3::Vector3(-cosTheta, -sinTheta, 0), PW); // invariant mass assigned to virtual W boson
 
-    // rotate the momentum vectors so they are defined wrt to the D lab frame direction
-    p4K_Drest.rotate(x_to_p3D_lab_rot);
-    p4W_Drest.rotate(x_to_p3D_lab_rot);
-    // perform the random "azimuth" rotation
-    double phi = random->Uniform(0, 2 * M_PI);
-    geom3::Rotation3 azimuth_rand_rot(p3D_lab_dir, phi);
-    p4K_Drest.rotate(azimuth_rand_rot);
-    p4W_Drest.rotate(azimuth_rand_rot);
-    // finally, boost the 4 momenta back to the lab frame
-    rk::Boost boost_from_Drest_to_lab = p4D_lab.labBoost();
-    rk::P4 p4K_lab = p4K_Drest.boost(boost_from_Drest_to_lab);
-    rk::P4 p4W_lab = p4W_Drest.boost(boost_from_Drest_to_lab);
+    // Kinematic limits for m23 (lepton-neutrino invariant mass)
+    double m23Min = ml + mnu;        // minimum: lepton + neutrino at rest
+    double m23Max = mD - mK;         // maximum: kaon at rest
+    double mDiff  = m23Max - m23Min;
 
-    // this ends the computation of D->W+K/Pi decay, now treat the W->l+nu decay
-    double ml = particleMass(record.signature.secondary_types[1]);
-    double mnu = 0;
-    double W_cosTheta = random->Uniform(-1, 1); // sampling the direction 
-    double W_sinTheta = std::sin(std::acos(W_cosTheta));
-    double El = (Q2 + pow(ml, 2)) / (2 * sqrt(Q2));
-    double Enu = (Q2 - pow(ml, 2)) / (2 * sqrt(Q2)); // the energies of the outgoing lepton and neutrino
-    double P = (Q2 - pow(ml, 2)) / (2 * sqrt(Q2));
-    // now we have thr four vectors of the outgoing particle kinematics in tne W rest frame wrt x direction
-    rk::P4 p4l_Wrest(P * geom3::Vector3(W_cosTheta, W_sinTheta, 0), ml);
-    rk::P4 p4nu_Wrest(P * geom3::Vector3(-W_cosTheta, -W_sinTheta, 0), 0);
+    // Maximum phase space weight: p1Max * p23Max
+    // p1Max = kaon momentum when m23 = m23Min
+    double p1Max = 0.5 * sqrt((mD - mK - m23Min) * (mD + mK + m23Min)
+                             * (mD + mK - m23Min) * (mD - mK + m23Min)) / mD;
+    // p23Max = lepton momentum in m23 rest frame when m23 = m23Max
+    double p23Max = 0.5 * sqrt((m23Max - ml - mnu) * (m23Max + ml + mnu)
+                              * (m23Max + ml - mnu) * (m23Max - ml + mnu)) / m23Max;
+    double wtPSmax = 0.5 * p1Max * p23Max;
 
-    geom3::Vector3 p3W_lab = p4W_lab.momentum();
-    geom3::UnitVector3 p3W_lab_dir = p3W_lab.direction();
-    geom3::Rotation3 x_to_p3W_lab_rot = geom3::rotationBetween(x_dir, p3W_lab_dir);
-    p4l_Wrest.rotate(x_to_p3W_lab_rot);
-    p4nu_Wrest.rotate(x_to_p3W_lab_rot);
-    // now finally perform the last aximuthal rotation
-    double W_phi = random->Uniform(0, 2 * M_PI);
-    geom3::Rotation3 W_azimuth_rand_rot(p3W_lab_dir, W_phi);
-    p4l_Wrest.rotate(W_azimuth_rand_rot);
-    p4nu_Wrest.rotate(W_azimuth_rand_rot);
-    rk::Boost boost_from_Wrest_to_lab = p4W_lab.labBoost();
-    rk::P4 p4l_lab = p4l_Wrest.boost(boost_from_Wrest_to_lab);
-    rk::P4 p4nu_lab = p4nu_Wrest.boost(boost_from_Wrest_to_lab);
+    // V-A matrix element upper bound (from Pythia, meMode == 22)
+    double wtMEmax = std::min(std::pow(mD, 4) / 16.0,
+                              mD * (mD - mK - ml) * (mD - mK - mnu) * (mD - ml - mnu));
+    double wtME;
 
+    rk::P4 p4K_Drest, p4l_Drest, p4nu_Drest;
+
+    do {
+    wtME = 1.0;
+
+    // --- Step 1: Sample m23 flat, accept-reject on phase space weight ---
+    double m23, p1Abs, p23Abs, wtPS;
+    do {
+        m23 = m23Min + random->Uniform(0, 1) * mDiff;
+
+        // p1Abs = kaon momentum in D rest frame for this m23
+        p1Abs = 0.5 * sqrt((mD - mK - m23) * (mD + mK + m23)
+                          * (mD + mK - m23) * (mD - mK + m23)) / mD;
+        // p23Abs = lepton momentum in m23 rest frame
+        p23Abs = 0.5 * sqrt((m23 - ml - mnu) * (m23 + ml + mnu)
+                           * (m23 + ml - mnu) * (m23 - ml + mnu)) / m23;
+        wtPS = p1Abs * p23Abs;
+    } while (wtPS < random->Uniform(0, 1) * wtPSmax);
+
+    // --- Step 2: Set up m23 -> lepton + neutrino isotropically ---
+    double cosTheta23 = random->Uniform(-1, 1);
+    double sinTheta23 = std::sin(std::acos(cosTheta23));
+    double phi23 = random->Uniform(0, 2 * M_PI);
+
+    // Lepton and neutrino in m23 rest frame
+    geom3::Vector3 dir23(sinTheta23 * std::cos(phi23),
+                         sinTheta23 * std::sin(phi23),
+                         cosTheta23);
+    rk::P4 p4l_m23rest(p23Abs * dir23, ml);
+    rk::P4 p4nu_m23rest(-p23Abs * dir23, mnu);
+
+    // --- Step 3: Set up D -> K + (m23 system) isotropically ---
+    double cosTheta1 = random->Uniform(-1, 1);
+    double sinTheta1 = std::sin(std::acos(cosTheta1));
+    double phi1 = random->Uniform(0, 2 * M_PI);
+
+    geom3::Vector3 dir1(sinTheta1 * std::cos(phi1),
+                        sinTheta1 * std::sin(phi1),
+                        cosTheta1);
+    // Kaon in D rest frame
+    p4K_Drest = rk::P4(p1Abs * dir1, mK);
+    // m23 system in D rest frame (opposite to kaon)
+    rk::P4 p4m23_Drest(-p1Abs * dir1, m23);
+
+    // --- Step 4: Boost lepton and neutrino from m23 rest frame to D rest frame ---
+    rk::Boost boost_m23_to_Drest = p4m23_Drest.labBoost();
+    p4l_Drest = p4l_m23rest.boost(boost_m23_to_Drest);
+    p4nu_Drest = p4nu_m23rest.boost(boost_m23_to_Drest);
+
+    // --- Step 5: V-A matrix element weight ---
+    // wtME = m_D * E_lepton * (p_neutrino . p_kaon) in D rest frame
+    // This is Lorentz invariant up to the m_D * E_l factor which equals p_D . p_l
+    wtME = mD * p4l_Drest.e() * p4nu_Drest.dot(p4K_Drest);
+
+    } while (wtME < random->Uniform(0, 1) * wtMEmax);
+
+    // --- Boost all particles from D rest frame to lab frame ---
+    rk::Boost boost_D_to_lab = p4D_lab.labBoost();
+    rk::P4 p4K_lab = p4K_Drest.boost(boost_D_to_lab);
+    rk::P4 p4l_lab = p4l_Drest.boost(boost_D_to_lab);
+    rk::P4 p4nu_lab = p4nu_Drest.boost(boost_D_to_lab);
+
+    // --- Set secondary particle records ---
     std::vector<siren::dataclasses::SecondaryParticleRecord> & secondaries = record.GetSecondaryParticleRecords();
     siren::dataclasses::SecondaryParticleRecord & kpi = secondaries[0];
     siren::dataclasses::SecondaryParticleRecord & lepton = secondaries[1];
-    siren::dataclasses::SecondaryParticleRecord & neutrino = secondaries[2]; //these are all hardcoded at the time
+    siren::dataclasses::SecondaryParticleRecord & neutrino = secondaries[2];
 
     kpi.SetFourMomentum({p4K_lab.e(), p4K_lab.px(), p4K_lab.py(), p4K_lab.pz()});
     kpi.SetMass(p4K_lab.m());

--- a/projects/interactions/private/PythiaDISCrossSection.cxx
+++ b/projects/interactions/private/PythiaDISCrossSection.cxx
@@ -1,0 +1,607 @@
+#include "SIREN/interactions/PythiaDISCrossSection.h"
+
+#include <map>
+#include <set>
+#include <array>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+#include <limits>
+#include <iostream>
+#include <stdexcept>
+
+#include <rk/rk.hh>
+#include <rk/geom3.hh>
+
+#include <photospline/splinetable.h>
+
+#include <Pythia8/Pythia.h>
+
+#include "SIREN/interactions/CrossSection.h"
+#include "SIREN/dataclasses/InteractionRecord.h"
+#include "SIREN/dataclasses/Particle.h"
+#include "SIREN/utilities/Random.h"
+#include "SIREN/utilities/Constants.h"
+
+namespace siren {
+namespace interactions {
+
+namespace {
+bool kinematicallyAllowed(double x, double y, double E, double M, double m) {
+    if(x > 1) return false;
+    if(x < ((m * m) / (2 * M * (E - m)))) return false;
+    if (x < 1e-6 || y < 1e-6) return false;
+    double d = 2 * (1 + (M * x) / (2 * E));
+    double ad = 1 - m * m * ((1 / (2 * M * E * x)) + (1 / (2 * E * E)));
+    double term = 1 - ((m * m) / (2 * M * E * x));
+    double bd = sqrt(term * term - ((m * m) / (E * E)));
+    double s = 2 * M * E;
+    double Q2 = s * x * y;
+    double Mc = siren::utilities::Constants::D0Mass;
+    return ((ad - bd) <= d * y and d * y <= (ad + bd)) && (Q2 * (1 - x) / x + pow(M, 2) >= pow(M + Mc, 2));
+}
+} // anonymous namespace
+
+// ── SIRENRndm: bridges SIREN RNG into Pythia ──
+
+class SIRENRndm : public Pythia8::RndmEngine {
+public:
+    mutable std::shared_ptr<siren::utilities::SIREN_random> rng_;
+    double flat() override { return rng_->Uniform(0.0, 1.0); }
+};
+
+// ── Constructors ──
+
+PythiaDISCrossSection::PythiaDISCrossSection() {}
+
+PythiaDISCrossSection::~PythiaDISCrossSection() = default;
+
+PythiaDISCrossSection::PythiaDISCrossSection(
+    std::string differential_filename,
+    std::string total_filename,
+    int interaction_type,
+    double target_mass,
+    double minimum_Q2,
+    std::set<siren::dataclasses::ParticleType> primary_types,
+    std::set<siren::dataclasses::ParticleType> target_types,
+    std::string pythia_data_path,
+    std::string pdf_set,
+    std::string units)
+    : primary_types_(primary_types),
+      target_types_(target_types),
+      interaction_type_(interaction_type),
+      target_mass_(target_mass),
+      minimum_Q2_(minimum_Q2),
+      pdf_set_(pdf_set),
+      pythia_data_path_(pythia_data_path)
+{
+    LoadFromFile(differential_filename, total_filename);
+    InitializeSignatures();
+    SetUnits(units);
+}
+
+PythiaDISCrossSection::PythiaDISCrossSection(
+    std::string differential_filename,
+    std::string total_filename,
+    int interaction_type,
+    double target_mass,
+    double minimum_Q2,
+    std::vector<siren::dataclasses::ParticleType> primary_types,
+    std::vector<siren::dataclasses::ParticleType> target_types,
+    std::string pythia_data_path,
+    std::string pdf_set,
+    std::string units)
+    : primary_types_(primary_types.begin(), primary_types.end()),
+      target_types_(target_types.begin(), target_types.end()),
+      interaction_type_(interaction_type),
+      target_mass_(target_mass),
+      minimum_Q2_(minimum_Q2),
+      pdf_set_(pdf_set),
+      pythia_data_path_(pythia_data_path)
+{
+    LoadFromFile(differential_filename, total_filename);
+    InitializeSignatures();
+    SetUnits(units);
+}
+
+// ── File I/O ──
+
+void PythiaDISCrossSection::SetUnits(std::string units) {
+    std::transform(units.begin(), units.end(), units.begin(),
+        [](unsigned char c){ return std::tolower(c); });
+    if(units == "cm") {
+        unit = 1.0;
+    } else if(units == "m") {
+        unit = 10000.0;
+    } else {
+        throw std::runtime_error("Cross section units not supported!");
+    }
+}
+
+void PythiaDISCrossSection::LoadFromFile(std::string dd_crossSectionFile, std::string total_crossSectionFile) {
+    differential_cross_section_ = photospline::splinetable<>(dd_crossSectionFile.c_str());
+    if(differential_cross_section_.get_ndim() != 3 && differential_cross_section_.get_ndim() != 2)
+        throw std::runtime_error("cross section spline has " + std::to_string(differential_cross_section_.get_ndim())
+                + " dimensions, should have either 3 or 2");
+    total_cross_section_ = photospline::splinetable<>(total_crossSectionFile.c_str());
+    if(total_cross_section_.get_ndim() != 1)
+        throw std::runtime_error("Total cross section spline has " + std::to_string(total_cross_section_.get_ndim())
+                + " dimensions, should have 1");
+}
+
+void PythiaDISCrossSection::LoadFromMemory(std::vector<char> & differential_data, std::vector<char> & total_data) {
+    differential_cross_section_.read_fits_mem(differential_data.data(), differential_data.size());
+    total_cross_section_.read_fits_mem(total_data.data(), total_data.size());
+}
+
+void PythiaDISCrossSection::ReadParamsFromSplineTable() {
+    bool mass_good = differential_cross_section_.read_key("TARGETMASS", target_mass_);
+    bool int_good = differential_cross_section_.read_key("INTERACTION", interaction_type_);
+    bool q2_good = differential_cross_section_.read_key("Q2MIN", minimum_Q2_);
+    if(!int_good) interaction_type_ = 1;
+    if(!q2_good) minimum_Q2_ = 1;
+    if(!mass_good) target_mass_ = siren::utilities::Constants::isoscalarMass;
+}
+
+// ── Equality ──
+
+bool PythiaDISCrossSection::equal(CrossSection const & other) const {
+    const PythiaDISCrossSection* x = dynamic_cast<const PythiaDISCrossSection*>(&other);
+    if(!x) return false;
+    return std::tie(interaction_type_, target_mass_, minimum_Q2_, signatures_, primary_types_, target_types_)
+        == std::tie(x->interaction_type_, x->target_mass_, x->minimum_Q2_, x->signatures_, x->primary_types_, x->target_types_);
+}
+
+// ── Particle ID helpers ──
+
+bool PythiaDISCrossSection::IsCharmedHadron(int pdgId) {
+    int abs_id = std::abs(pdgId);
+    // Only match D0 (421) and D+/- (411) for now.
+    // TODO: Add Ds (431) and Lambda_c (4122) support — need CharmMesonDecay
+    // to handle these types before they can be registered as signatures.
+    // Currently Ds/Lambda_c end up in the hadronic remnant.
+    return (abs_id == 411 || abs_id == 421);
+}
+
+siren::dataclasses::ParticleType PythiaDISCrossSection::PdgToParticleType(int pdgId) {
+    // Direct cast — SIREN ParticleType enum values match PDG codes
+    return static_cast<siren::dataclasses::ParticleType>(pdgId);
+}
+
+double PythiaDISCrossSection::GetLeptonMass(siren::dataclasses::ParticleType lepton_type) {
+    int32_t lepton_number = std::abs(static_cast<int32_t>(lepton_type));
+    switch(lepton_number) {
+        case 11: return siren::utilities::Constants::electronMass;
+        case 13: return siren::utilities::Constants::muonMass;
+        case 15: return siren::utilities::Constants::tauMass;
+        case 12: case 14: case 16: return 0;
+        default: throw std::runtime_error("Unknown lepton type!");
+    }
+}
+
+double PythiaDISCrossSection::GetHadronMass(siren::dataclasses::ParticleType hadron_type) {
+    switch(hadron_type) {
+        case siren::dataclasses::ParticleType::D0:
+        case siren::dataclasses::ParticleType::D0Bar:
+            return siren::utilities::Constants::D0Mass;
+        case siren::dataclasses::ParticleType::DPlus:
+        case siren::dataclasses::ParticleType::DMinus:
+            return siren::utilities::Constants::DPlusMass;
+        default:
+            return 0.0;
+    }
+}
+
+std::map<std::string, int> PythiaDISCrossSection::getIndices(siren::dataclasses::InteractionSignature signature) {
+    int lepton_id = -1, hadron_id = -1, meson_id = -1;
+    for (size_t i = 0; i < signature.secondary_types.size(); i++) {
+        if (siren::dataclasses::isLepton(signature.secondary_types[i])) {
+            lepton_id = i;
+        } else if (siren::dataclasses::isD(signature.secondary_types[i])) {
+            meson_id = i;
+        } else {
+            hadron_id = i;
+        }
+    }
+    return {{"lepton", lepton_id}, {"hadron", hadron_id}, {"meson", meson_id}};
+}
+
+// ── Signatures ──
+
+void PythiaDISCrossSection::InitializeSignatures() {
+    signatures_.clear();
+    for(auto primary_type : primary_types_) {
+        dataclasses::InteractionSignature signature;
+        signature.primary_type = primary_type;
+        if(not siren::dataclasses::isNeutrino(primary_type)) {
+            throw std::runtime_error("PythiaDISCrossSection only supports neutrinos as primaries!");
+        }
+
+        siren::dataclasses::ParticleType charged_lepton_product = siren::dataclasses::ParticleType::unknown;
+        siren::dataclasses::ParticleType neutral_lepton_product = primary_type;
+
+        if(primary_type == siren::dataclasses::ParticleType::NuE) {
+            charged_lepton_product = siren::dataclasses::ParticleType::EMinus;
+        } else if(primary_type == siren::dataclasses::ParticleType::NuEBar) {
+            charged_lepton_product = siren::dataclasses::ParticleType::EPlus;
+        } else if(primary_type == siren::dataclasses::ParticleType::NuMu) {
+            charged_lepton_product = siren::dataclasses::ParticleType::MuMinus;
+        } else if(primary_type == siren::dataclasses::ParticleType::NuMuBar) {
+            charged_lepton_product = siren::dataclasses::ParticleType::MuPlus;
+        } else if(primary_type == siren::dataclasses::ParticleType::NuTau) {
+            charged_lepton_product = siren::dataclasses::ParticleType::TauMinus;
+        } else if(primary_type == siren::dataclasses::ParticleType::NuTauBar) {
+            charged_lepton_product = siren::dataclasses::ParticleType::TauPlus;
+        } else {
+            throw std::runtime_error("InitializeSignatures: Unknown parent neutrino type!");
+        }
+
+        if(interaction_type_ == 1) {
+            signature.secondary_types.push_back(charged_lepton_product);
+        } else if(interaction_type_ == 2) {
+            signature.secondary_types.push_back(neutral_lepton_product);
+        } else {
+            throw std::runtime_error("InitializeSignatures: Unknown interaction type!");
+        }
+
+        // Hadron remnant
+        signature.secondary_types.push_back(siren::dataclasses::ParticleType::Hadrons);
+
+        // Charmed meson types: always D0 and DPlus regardless of nu/nubar.
+        // This matches the existing CharmHadronization convention and ensures
+        // compatibility with CharmMesonDecay (which only supports D0/DPlus).
+        // TODO: Add Ds (431) and Lambda_c (4122) support.
+        D_types_ = {siren::dataclasses::ParticleType::D0,
+                    siren::dataclasses::ParticleType::DPlus};
+
+        for (auto meson_type : D_types_) {
+            dataclasses::InteractionSignature full_signature = signature;
+            full_signature.secondary_types.push_back(meson_type);
+            for(auto target_type : target_types_) {
+                full_signature.target_type = target_type;
+                signatures_.push_back(full_signature);
+                std::pair<siren::dataclasses::ParticleType, siren::dataclasses::ParticleType> key(primary_type, target_type);
+                signatures_by_parent_types_[key].push_back(full_signature);
+            }
+        }
+    }
+}
+
+// ── Cross sections (from splines, same as QuarkDISFromSpline) ──
+
+double PythiaDISCrossSection::TotalCrossSection(dataclasses::InteractionRecord const & interaction) const {
+    siren::dataclasses::ParticleType primary_type = interaction.signature.primary_type;
+    double primary_energy = interaction.primary_momentum[0];
+    if(primary_energy < InteractionThreshold(interaction)) return 0;
+    return TotalCrossSection(primary_type, primary_energy);
+}
+
+double PythiaDISCrossSection::TotalCrossSection(siren::dataclasses::ParticleType primary_type, double primary_energy) const {
+    if(not primary_types_.count(primary_type)) {
+        throw std::runtime_error("Supplied primary not supported by cross section!");
+    }
+    double log_energy = log10(primary_energy);
+    if(log_energy < total_cross_section_.lower_extent(0)
+            or log_energy > total_cross_section_.upper_extent(0)) {
+        throw std::runtime_error("Interaction energy out of cross section table range");
+    }
+    int center;
+    total_cross_section_.searchcenters(&log_energy, &center);
+    double log_xs = total_cross_section_.ndsplineeval(&log_energy, &center, 0);
+    return unit * std::pow(10.0, log_xs);
+}
+
+double PythiaDISCrossSection::TotalCrossSectionAllFinalStates(dataclasses::InteractionRecord const & record) const {
+    return TotalCrossSection(record);
+}
+
+double PythiaDISCrossSection::DifferentialCrossSection(dataclasses::InteractionRecord const & interaction) const {
+    rk::P4 p1(geom3::Vector3(interaction.primary_momentum[1], interaction.primary_momentum[2], interaction.primary_momentum[3]), interaction.primary_mass);
+    rk::P4 p2(geom3::Vector3(0, 0, 0), interaction.target_mass);
+    double primary_energy = interaction.primary_momentum[0];
+
+    std::map<std::string, int> secondaries = getIndices(interaction.signature);
+    unsigned int lepton_index = secondaries["lepton"];
+
+    std::array<double, 4> const & mom3 = interaction.secondary_momenta[lepton_index];
+    rk::P4 p3(geom3::Vector3(mom3[1], mom3[2], mom3[3]), interaction.secondary_masses[lepton_index]);
+    rk::P4 q = p1 - p3;
+
+    double Q2 = -q.dot(q);
+    double lepton_mass = GetLeptonMass(interaction.signature.secondary_types[lepton_index]);
+    double y = 1.0 - p2.dot(p3) / p2.dot(p1);
+    double x = Q2 / (2.0 * p2.dot(q));
+
+    double log_energy = log10(primary_energy);
+    std::array<double,3> coordinates{{log_energy, log10(x), log10(y)}};
+    std::array<int,3> centers;
+
+    if (Q2 < minimum_Q2_ || !kinematicallyAllowed(x, y, primary_energy, target_mass_, lepton_mass)
+        || !differential_cross_section_.searchcenters(coordinates.data(), centers.data())) {
+        // Fall back to saved parameters
+        x = interaction.interaction_parameters.at("bjorken_x");
+        y = interaction.interaction_parameters.at("bjorken_y");
+        Q2 = 2. * primary_energy * p2.e() * x * y;
+    }
+    return DifferentialCrossSection(primary_energy, x, y, lepton_mass, Q2);
+}
+
+double PythiaDISCrossSection::DifferentialCrossSection(double energy, double x, double y, double secondary_lepton_mass, double Q2) const {
+    double log_energy = log10(energy);
+    if(log_energy < differential_cross_section_.lower_extent(0)
+            || log_energy > differential_cross_section_.upper_extent(0))
+        return 0.0;
+    if(x <= 0 || x >= 1) return 0.0;
+    if(y <= 0 || y >= 1) return 0.0;
+    if(std::isnan(Q2)) Q2 = 2.0 * energy * target_mass_ * x * y;
+    if(Q2 < minimum_Q2_) return 0;
+    if(!kinematicallyAllowed(x, y, energy, target_mass_, secondary_lepton_mass)) return 0;
+
+    std::array<double,3> coordinates{{log_energy, log10(x), log10(y)}};
+    std::array<int,3> centers;
+    if(!differential_cross_section_.searchcenters(coordinates.data(), centers.data())) return 0;
+    double result = pow(10., differential_cross_section_.ndsplineeval(coordinates.data(), centers.data(), 0));
+    return unit * result;
+}
+
+double PythiaDISCrossSection::InteractionThreshold(dataclasses::InteractionRecord const & interaction) const {
+    return 0;
+}
+
+// ── Fragmentation fractions ──
+
+double PythiaDISCrossSection::FragmentationFraction(siren::dataclasses::Particle::ParticleType secondary) const {
+    // Approximate fractions from Pythia (charm hadronization)
+    if (secondary == siren::dataclasses::ParticleType::D0 || secondary == siren::dataclasses::ParticleType::D0Bar) {
+        return 0.6;
+    } else if (secondary == siren::dataclasses::ParticleType::DPlus || secondary == siren::dataclasses::ParticleType::DMinus) {
+        return 0.23;
+    }
+    // TODO: Add Ds (~0.08) and Lambda_c (~0.09) when signatures include them
+    return 0;
+}
+
+double PythiaDISCrossSection::FinalStateProbability(dataclasses::InteractionRecord const & interaction) const {
+    // Pythia samples final-state kinematics from the physical distribution,
+    // so no differential reweighting is needed. FinalStateProbability appears
+    // in both physical_probability and generation_probability and cancels.
+    return 1.0;
+}
+
+// ── Signature accessors ──
+
+std::vector<siren::dataclasses::ParticleType> PythiaDISCrossSection::GetPossiblePrimaries() const {
+    return std::vector<siren::dataclasses::ParticleType>(primary_types_.begin(), primary_types_.end());
+}
+
+std::vector<siren::dataclasses::ParticleType> PythiaDISCrossSection::GetPossibleTargetsFromPrimary(siren::dataclasses::ParticleType primary_type) const {
+    return std::vector<siren::dataclasses::ParticleType>(target_types_.begin(), target_types_.end());
+}
+
+std::vector<dataclasses::InteractionSignature> PythiaDISCrossSection::GetPossibleSignatures() const {
+    return std::vector<dataclasses::InteractionSignature>(signatures_.begin(), signatures_.end());
+}
+
+std::vector<siren::dataclasses::ParticleType> PythiaDISCrossSection::GetPossibleTargets() const {
+    return std::vector<siren::dataclasses::ParticleType>(target_types_.begin(), target_types_.end());
+}
+
+std::vector<dataclasses::InteractionSignature> PythiaDISCrossSection::GetPossibleSignaturesFromParents(siren::dataclasses::ParticleType primary_type, siren::dataclasses::ParticleType target_type) const {
+    std::pair<siren::dataclasses::ParticleType, siren::dataclasses::ParticleType> key(primary_type, target_type);
+    if(signatures_by_parent_types_.find(key) != signatures_by_parent_types_.end()) {
+        return signatures_by_parent_types_.at(key);
+    }
+    return std::vector<dataclasses::InteractionSignature>();
+}
+
+std::vector<std::string> PythiaDISCrossSection::DensityVariables() const {
+    return std::vector<std::string>{"Bjorken x", "Bjorken y"};
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Pythia initialization and SampleFinalState — the core new logic
+// ══════════════════════════════════════════════════════════════════════
+
+void PythiaDISCrossSection::InitializePythia(double E_nu) const {
+    // Ensure LHAPDF can find PDF sets — derive data path from the LHAPDF library location
+    // The pdf_set_ is e.g. "LHAPDF6:HERAPDF20_NLO_EIG", and LHAPDF needs LHAPDF_DATA_PATH set
+    const char* lhapdf_path = std::getenv("LHAPDF_DATA_PATH");
+    if (!lhapdf_path) {
+        // Try a reasonable default based on common install layouts
+        std::string default_path = "/n/holylfs05/LABS/arguelles_delgado_lab/Everyone/pzhelnin/LHAPDF/new_install/share/LHAPDF";
+        setenv("LHAPDF_DATA_PATH", default_path.c_str(), 0);
+    }
+
+    pythia_ = std::make_unique<Pythia8::Pythia>(pythia_data_path_, false);
+
+    // Determine beam particle from primary types
+    int beam_id = 14; // default nu_mu
+    for (auto pt : primary_types_) {
+        beam_id = static_cast<int>(pt);
+        break; // use the first primary type
+    }
+
+    // Process selection
+    if (interaction_type_ == 1) {
+        pythia_->readString("WeakBosonExchange:ff2ff(t:W) = on");
+    } else if (interaction_type_ == 2) {
+        pythia_->readString("WeakBosonExchange:ff2ff(t:gmZ) = on");
+    }
+
+    // Beam setup: fixed target
+    pythia_->readString("Beams:frameType = 2");
+    pythia_->readString("Beams:idA = " + std::to_string(beam_id));
+    pythia_->readString("Beams:idB = 2212");
+    pythia_->readString("Beams:eA = " + std::to_string(E_nu));
+    pythia_->readString("Beams:eB = 0.");
+
+    // Force charm-only for CC: zero out non-charm CKM elements
+    // Must use forceParm to bypass Pythia's range checks
+    if (interaction_type_ == 1) {
+        pythia_->settings.forceParm("StandardModel:Vud", 0.0);
+        pythia_->settings.forceParm("StandardModel:Vus", 0.0);
+        pythia_->settings.forceParm("StandardModel:Vub", 0.0);
+        pythia_->settings.forceParm("StandardModel:Vcb", 0.0);
+        // Keeps Vcd ~ 0.225 and Vcs ~ 0.973 → every CC event produces charm
+    }
+
+    // PDF
+    pythia_->readString("PDF:pSet = " + pdf_set_);
+    pythia_->readString("PDF:useHard = on");
+    pythia_->readString("PDF:pHardSet = " + pdf_set_);
+
+    // Hadronization: string fragmentation ON, D decays OFF
+    pythia_->readString("HadronLevel:Hadronize = on");
+    pythia_->readString("HadronLevel:Decay = off");
+
+    // Disable MPI
+    pythia_->readString("PartonLevel:MPI = off");
+
+    // Phase space: remove mHatMin (default 4 GeV) to allow full kinematic range.
+    // Keep pTHatMinDiverge at default (1 GeV), giving effective Q2 > 1 GeV^2.
+    pythia_->readString("PhaseSpace:mHatMin = 0.0");
+    pythia_->readString("PhaseSpace:Q2Min = " + std::to_string(minimum_Q2_));
+
+    pythia_->readString("Print:quiet = on");
+
+    if (!pythia_->init()) {
+        throw std::runtime_error("PythiaDISCrossSection: Pythia initialization failed");
+    }
+
+    // Bridge SIREN RNG into Pythia for reproducibility.
+    // Must be done after init() — init uses Pythia's internal RNG for setup.
+    // The SIREN RNG is connected here and updated per-event in SampleFinalState.
+    siren_rndm_ = std::make_shared<SIRENRndm>();
+    pythia_->rndm.rndmEnginePtr(siren_rndm_);
+
+    pythia_initialized_ = true;
+}
+
+void PythiaDISCrossSection::SampleFinalState(dataclasses::CrossSectionDistributionRecord & record, std::shared_ptr<siren::utilities::SIREN_random> random) const {
+    // Get indices for lepton, hadron, meson in the secondary list
+    std::map<std::string, int> secondary_indices = getIndices(record.signature);
+    unsigned int lepton_index = secondary_indices["lepton"];
+    unsigned int hadron_index = secondary_indices["hadron"];
+    unsigned int meson_index = secondary_indices["meson"];
+
+    // Get primary neutrino 4-momentum
+    rk::P4 p1(geom3::Vector3(record.primary_momentum[1], record.primary_momentum[2], record.primary_momentum[3]), record.primary_mass);
+    double E_nu = p1.e();
+    geom3::UnitVector3 nu_dir = p1.momentum().direction();
+
+    // Initialize or update Pythia
+    if (!pythia_initialized_) {
+        InitializePythia(E_nu);
+    }
+
+    // For now, reinitialize if energy changes significantly
+    // TODO: test setKinematics stability across energy ranges
+
+    // Bridge the SIREN RNG for this event
+    siren_rndm_->rng_ = random;
+
+    // Generate a Pythia event
+    int max_attempts = 100;
+    bool found_charm = false;
+    for (int attempt = 0; attempt < max_attempts; ++attempt) {
+        if (!pythia_->next()) {
+            continue;
+        }
+
+        // Find the muon and charmed hadron in the final state
+        int i_muon = -1;
+        int i_charm = -1;
+        Pythia8::Vec4 p_remnant(0., 0., 0., 0.);
+
+        for (int i = 0; i < pythia_->event.size(); ++i) {
+            if (!pythia_->event[i].isFinal()) continue;
+
+            int pid = pythia_->event[i].id();
+            int abs_pid = std::abs(pid);
+
+            if (abs_pid == 13 && i_muon < 0) {
+                // Primary muon (first one found)
+                i_muon = i;
+            } else if (IsCharmedHadron(pid) && i_charm < 0) {
+                // First charmed hadron
+                i_charm = i;
+            } else {
+                // Everything else goes into the remnant
+                p_remnant += pythia_->event[i].p();
+            }
+        }
+
+        if (i_muon >= 0 && i_charm >= 0) {
+            found_charm = true;
+
+            // Extract 4-momenta from Pythia (in Pythia's frame: nu along +z)
+            Pythia8::Vec4 p_mu_pythia = pythia_->event[i_muon].p();
+            Pythia8::Vec4 p_D_pythia = pythia_->event[i_charm].p();
+
+            // Get Pythia's DIS kinematics for weighting
+            double pythia_x = pythia_->info.x2();  // proton PDF x (beam B)
+            double pythia_y = 1.0 - p_mu_pythia.e() / E_nu;
+
+            // Store in interaction parameters for weighting
+            record.interaction_parameters.clear();
+            record.interaction_parameters["energy"] = E_nu;
+            record.interaction_parameters["bjorken_x"] = pythia_x;
+            record.interaction_parameters["bjorken_y"] = pythia_y;
+
+            // Rotate from Pythia frame (+z) to SIREN's neutrino direction
+            geom3::UnitVector3 z_dir = geom3::UnitVector3::zAxis();
+            geom3::Rotation3 rot = geom3::rotationBetween(z_dir, nu_dir);
+
+            // Helper lambda to convert Pythia Vec4 → rotated rk::P4
+            auto pythia_to_siren = [&](const Pythia8::Vec4 & pv, double mass) -> rk::P4 {
+                geom3::Vector3 mom(pv.px(), pv.py(), pv.pz());
+                mom = rot * mom;
+                return rk::P4(mom, mass);
+            };
+
+            double muon_mass = pythia_->event[i_muon].m();
+            double D_mass = pythia_->event[i_charm].m();
+            double remnant_mass = std::sqrt(std::max(0.0,
+                p_remnant.e() * p_remnant.e() -
+                p_remnant.px() * p_remnant.px() -
+                p_remnant.py() * p_remnant.py() -
+                p_remnant.pz() * p_remnant.pz()));
+
+            rk::P4 p3 = pythia_to_siren(p_mu_pythia, muon_mass);
+            rk::P4 p_D = pythia_to_siren(p_D_pythia, D_mass);
+
+            // Remnant
+            geom3::Vector3 rem_mom(p_remnant.px(), p_remnant.py(), p_remnant.pz());
+            rem_mom = rot * rem_mom;
+            rk::P4 p_rem(rem_mom, remnant_mass);
+
+            // Set secondaries
+            std::vector<siren::dataclasses::SecondaryParticleRecord> & secondaries = record.GetSecondaryParticleRecords();
+            siren::dataclasses::SecondaryParticleRecord & lepton = secondaries[lepton_index];
+            siren::dataclasses::SecondaryParticleRecord & hadron = secondaries[hadron_index];
+            siren::dataclasses::SecondaryParticleRecord & meson = secondaries[meson_index];
+
+            lepton.SetFourMomentum({p3.e(), p3.px(), p3.py(), p3.pz()});
+            lepton.SetMass(muon_mass);
+            lepton.SetHelicity(record.primary_helicity);
+
+            hadron.SetFourMomentum({p_rem.e(), p_rem.px(), p_rem.py(), p_rem.pz()});
+            hadron.SetMass(remnant_mass);
+            hadron.SetHelicity(record.target_helicity);
+
+            meson.SetFourMomentum({p_D.e(), p_D.px(), p_D.py(), p_D.pz()});
+            meson.SetMass(D_mass);
+            meson.SetHelicity(record.target_helicity);
+
+            break;
+        }
+    }
+
+    if (!found_charm) {
+        throw std::runtime_error("PythiaDISCrossSection::SampleFinalState: Failed to generate charm event after " + std::to_string(max_attempts) + " attempts");
+    }
+}
+
+} // namespace interactions
+} // namespace siren

--- a/projects/interactions/private/QuarkDISFromSpline.cxx
+++ b/projects/interactions/private/QuarkDISFromSpline.cxx
@@ -450,6 +450,12 @@ double QuarkDISFromSpline::TotalCrossSection(dataclasses::InteractionRecord cons
         std::cout << "DIS::interaction threshold not satisfied" << std::endl;
         return 0;
     }
+
+    //check of the signature of what the final state hadron is
+    //there should be fragmentation fraction 
+    //multiply with fragmentation fraction for dmeson final state 
+    //the overloaded function needs fragmentation fraction. 
+
     return TotalCrossSection(primary_type, primary_energy);
 }
 
@@ -476,6 +482,14 @@ double QuarkDISFromSpline::TotalCrossSection(siren::dataclasses::ParticleType pr
     }
 
     return unit * std::pow(10.0, log_xs);
+}
+
+double QuarkDISFromSpline::TotalCrossSectionAllFinalStates(dataclasses::InteractionRecord const & record) const {
+    // The total cross section spline already represents the full charm production
+    // cross section, not a per-meson-type cross section. Override the base class
+    // implementation which would sum TotalCrossSection once per signature (D0, DPlus),
+    // double-counting.
+    return TotalCrossSection(record);
 }
 
 double QuarkDISFromSpline::DifferentialCrossSection(dataclasses::InteractionRecord const & interaction) const {

--- a/projects/interactions/private/pybindings/PythiaDISCrossSection.h
+++ b/projects/interactions/private/pybindings/PythiaDISCrossSection.h
@@ -1,0 +1,70 @@
+#include <set>
+#include <memory>
+#include <string>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "../../public/SIREN/interactions/CrossSection.h"
+#include "../../public/SIREN/interactions/PythiaDISCrossSection.h"
+#include "../../../dataclasses/public/SIREN/dataclasses/Particle.h"
+#include "../../../dataclasses/public/SIREN/dataclasses/InteractionRecord.h"
+#include "../../../dataclasses/public/SIREN/dataclasses/InteractionSignature.h"
+#include "../../../geometry/public/SIREN/geometry/Geometry.h"
+#include "../../../utilities/public/SIREN/utilities/Random.h"
+
+void register_PythiaDISCrossSection(pybind11::module_ & m) {
+    using namespace pybind11;
+    using namespace siren::interactions;
+
+    class_<PythiaDISCrossSection, std::shared_ptr<PythiaDISCrossSection>, CrossSection> pythiadis(m, "PythiaDISCrossSection");
+
+    pythiadis
+
+        .def(init<>())
+        .def(init<std::string, std::string, int, double, double,
+                   std::set<siren::dataclasses::ParticleType>,
+                   std::set<siren::dataclasses::ParticleType>,
+                   std::string, std::string, std::string>(),
+                arg("differential_filename"),
+                arg("total_filename"),
+                arg("interaction_type"),
+                arg("target_mass"),
+                arg("minimum_Q2"),
+                arg("primary_types"),
+                arg("target_types"),
+                arg("pythia_data_path"),
+                arg("pdf_set") = std::string("LHAPDF6:HERAPDF20_NLO_EIG"),
+                arg("units") = std::string("cm"))
+        .def(init<std::string, std::string, int, double, double,
+                   std::vector<siren::dataclasses::ParticleType>,
+                   std::vector<siren::dataclasses::ParticleType>,
+                   std::string, std::string, std::string>(),
+                arg("differential_filename"),
+                arg("total_filename"),
+                arg("interaction_type"),
+                arg("target_mass"),
+                arg("minimum_Q2"),
+                arg("primary_types"),
+                arg("target_types"),
+                arg("pythia_data_path"),
+                arg("pdf_set") = std::string("LHAPDF6:HERAPDF20_NLO_EIG"),
+                arg("units") = std::string("cm"))
+        .def(self == self)
+        .def("TotalCrossSection",overload_cast<siren::dataclasses::InteractionRecord const &>(&PythiaDISCrossSection::TotalCrossSection, const_))
+        .def("TotalCrossSection",overload_cast<siren::dataclasses::ParticleType, double>(&PythiaDISCrossSection::TotalCrossSection, const_))
+        .def("DifferentialCrossSection",overload_cast<siren::dataclasses::InteractionRecord const &>(&PythiaDISCrossSection::DifferentialCrossSection, const_))
+        .def("DifferentialCrossSection",overload_cast<double, double, double, double, double>(&PythiaDISCrossSection::DifferentialCrossSection, const_))
+        .def("InteractionThreshold",&PythiaDISCrossSection::InteractionThreshold)
+        .def("FragmentationFraction",&PythiaDISCrossSection::FragmentationFraction)
+        .def("GetPossibleTargets",&PythiaDISCrossSection::GetPossibleTargets)
+        .def("GetPossibleTargetsFromPrimary",&PythiaDISCrossSection::GetPossibleTargetsFromPrimary)
+        .def("GetPossiblePrimaries",&PythiaDISCrossSection::GetPossiblePrimaries)
+        .def("GetPossibleSignatures",&PythiaDISCrossSection::GetPossibleSignatures)
+        .def("GetPossibleSignaturesFromParents",&PythiaDISCrossSection::GetPossibleSignaturesFromParents)
+        .def("FinalStateProbability",&PythiaDISCrossSection::FinalStateProbability)
+        .def("GetMinimumQ2",&PythiaDISCrossSection::GetMinimumQ2)
+        .def("GetTargetMass",&PythiaDISCrossSection::GetTargetMass)
+        .def("GetInteractionType",&PythiaDISCrossSection::GetInteractionType);
+}

--- a/projects/interactions/private/pybindings/interactions.cxx
+++ b/projects/interactions/private/pybindings/interactions.cxx
@@ -15,6 +15,7 @@
 #include "../../public/SIREN/interactions/CharmHadronization.h"
 #include "../../public/SIREN/interactions/CharmMesonDecay.h"
 #include "../../public/SIREN/interactions/DMesonELoss.h"
+#include "../../public/SIREN/interactions/PythiaDISCrossSection.h"
 
 #include "./CrossSection.h"
 #include "./DipoleFromTable.h"
@@ -32,6 +33,7 @@
 #include "./CharmHadronization.h"
 #include "./CharmMesonDecay.h"
 #include "./DMesonELoss.h"
+#include "./PythiaDISCrossSection.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
@@ -62,4 +64,5 @@ PYBIND11_MODULE(interactions,m) {
     register_NeutrissimoDecay(m);
     register_InteractionCollection(m);
     register_DummyCrossSection(m);
+    register_PythiaDISCrossSection(m);
 }

--- a/projects/interactions/public/SIREN/interactions/PythiaDISCrossSection.h
+++ b/projects/interactions/public/SIREN/interactions/PythiaDISCrossSection.h
@@ -1,15 +1,14 @@
 #pragma once
-#ifndef SIREN_QuarkDISFromSpline_H
-#define SIREN_QuarkDISFromSpline_H
+#ifndef SIREN_PythiaDISCrossSection_H
+#define SIREN_PythiaDISCrossSection_H
 
-#include <set>                                                // for set
-#include <map>                                                // for map
+#include <set>
+#include <map>
 #include <memory>
-#include <vector>                                             // for vector
-#include <cstdint>                                            // for uint32_t
-#include <utility>                                            // for pair
-#include <algorithm>
-#include <stdexcept>                                          // for runtime...
+#include <vector>
+#include <cstdint>
+#include <utility>
+#include <string>
 
 #include <cereal/cereal.hpp>
 #include <cereal/archives/json.hpp>
@@ -24,11 +23,14 @@
 #include <photospline/splinetable.h>
 #include <photospline/cinter/splinetable.h>
 
-#include "SIREN/interactions/CrossSection.h"        // for CrossSe...
-#include "SIREN/dataclasses/InteractionSignature.h"  // for Interac...
-#include "SIREN/dataclasses/Particle.h"              // for Particle
-#include "SIREN/utilities/Interpolator.h"
-#include "SIREN/utilities/Integration.h"
+#include "SIREN/interactions/CrossSection.h"
+#include "SIREN/dataclasses/InteractionSignature.h"
+#include "SIREN/dataclasses/Particle.h"
+
+// Forward declarations for Pythia
+namespace Pythia8 {
+    class Pythia;
+}
 
 namespace siren { namespace dataclasses { class InteractionRecord; } }
 namespace siren { namespace utilities { class SIREN_random; } }
@@ -36,48 +38,89 @@ namespace siren { namespace utilities { class SIREN_random; } }
 namespace siren {
 namespace interactions {
 
-class QuarkDISFromSpline : public CrossSection {
+// Forward declaration — defined in .cxx
+class SIRENRndm;
+
+class PythiaDISCrossSection : public CrossSection {
 friend cereal::access;
 private:
+    // Splines for total/differential cross section (SIREN weighting)
     photospline::splinetable<> differential_cross_section_;
     photospline::splinetable<> total_cross_section_;
 
+    // Pythia instance (mutable because SampleFinalState is const)
+    mutable std::unique_ptr<Pythia8::Pythia> pythia_;
+    mutable bool pythia_initialized_ = false;
+    mutable std::shared_ptr<SIRENRndm> siren_rndm_;
+
+    // Signature bookkeeping
     std::vector<dataclasses::InteractionSignature> signatures_;
     std::set<siren::dataclasses::ParticleType> primary_types_;
     std::set<siren::dataclasses::ParticleType> target_types_;
     std::map<siren::dataclasses::ParticleType, std::vector<siren::dataclasses::ParticleType>> targets_by_primary_types_;
     std::map<std::pair<siren::dataclasses::ParticleType, siren::dataclasses::ParticleType>, std::vector<dataclasses::InteractionSignature>> signatures_by_parent_types_;
     std::set<siren::dataclasses::ParticleType> D_types_;
-    
-    // used by the DIS process
-    int interaction_type_;
-    int quark_type_;
+
+    // DIS parameters
+    int interaction_type_;  // 1=CC, 2=NC
     double target_mass_;
     double minimum_Q2_;
-
-    // used by the hadronization process
-    double fragmentation_integral = 0; // for storing the integrated unnormed pdf
-    void normalize_pdf(); // for normalizing pdf and integral, to be called at initialization
-    siren::utilities::Interpolator1D<double> inverseCdfTable; // for storing the CDF-1 table for the hadronization
-    
     double unit;
 
-public:
-    QuarkDISFromSpline();
-    QuarkDISFromSpline(std::vector<char> differential_data, std::vector<char> total_data, int interaction, int quark_type, double target_mass, double minumum_Q2, std::set<siren::dataclasses::ParticleType> primary_types, std::set<siren::dataclasses::ParticleType> target_types, std::string units = "cm");
-    QuarkDISFromSpline(std::vector<char> differential_data, std::vector<char> total_data, int interaction, int quark_type, double target_mass, double minumum_Q2, std::vector<siren::dataclasses::ParticleType> primary_types, std::vector<siren::dataclasses::ParticleType> target_types, std::string units = "cm");
-    QuarkDISFromSpline(std::string differential_filename, std::string total_filename, int interaction, int quark_type, double target_mass, double minumum_Q2, std::set<siren::dataclasses::ParticleType> primary_types, std::set<siren::dataclasses::ParticleType> target_types, std::string units = "cm");
-    QuarkDISFromSpline(std::string differential_filename, std::string total_filename, std::set<siren::dataclasses::ParticleType> primary_types, std::set<siren::dataclasses::ParticleType> target_types, std::string units = "cm");
-    QuarkDISFromSpline(std::string differential_filename, std::string total_filename, int interaction, int quark_type, double target_mass, double minumum_Q2, std::vector<siren::dataclasses::ParticleType> primary_types, std::vector<siren::dataclasses::ParticleType> target_types, std::string units = "cm");
-    QuarkDISFromSpline(std::string differential_filename, std::string total_filename, std::vector<siren::dataclasses::ParticleType> primary_types, std::vector<siren::dataclasses::ParticleType> target_types, std::string units = "cm");
-    
+    // Pythia configuration
+    std::string pdf_set_;
+    std::string pythia_data_path_;
+
+    // Helper methods
+    void InitializePythia(double E_nu) const;
+    void InitializeSignatures();
+    void LoadFromFile(std::string differential_filename, std::string total_filename);
+    void LoadFromMemory(std::vector<char> & differential_data, std::vector<char> & total_data);
+    void ReadParamsFromSplineTable();
     void SetUnits(std::string units);
-    void SetInteractionType(int interaction);
-    void SetQuarkType(int q_type);
+
+    // Particle ID helpers
+    static bool IsCharmedHadron(int pdgId);
+    static siren::dataclasses::ParticleType PdgToParticleType(int pdgId);
+    static double GetLeptonMass(siren::dataclasses::ParticleType lepton_type);
+    static double GetHadronMass(siren::dataclasses::ParticleType hadron_type);
+    static std::map<std::string, int> getIndices(siren::dataclasses::InteractionSignature signature);
+
+public:
+    PythiaDISCrossSection();
+    ~PythiaDISCrossSection();
+
+    // Main constructor
+    PythiaDISCrossSection(
+        std::string differential_filename,
+        std::string total_filename,
+        int interaction_type,
+        double target_mass,
+        double minimum_Q2,
+        std::set<siren::dataclasses::ParticleType> primary_types,
+        std::set<siren::dataclasses::ParticleType> target_types,
+        std::string pythia_data_path,
+        std::string pdf_set = "LHAPDF6:HERAPDF20_NLO_EIG",
+        std::string units = "cm"
+    );
+
+    // Constructor with vectors
+    PythiaDISCrossSection(
+        std::string differential_filename,
+        std::string total_filename,
+        int interaction_type,
+        double target_mass,
+        double minimum_Q2,
+        std::vector<siren::dataclasses::ParticleType> primary_types,
+        std::vector<siren::dataclasses::ParticleType> target_types,
+        std::string pythia_data_path,
+        std::string pdf_set = "LHAPDF6:HERAPDF20_NLO_EIG",
+        std::string units = "cm"
+    );
 
     virtual bool equal(CrossSection const & other) const override;
 
-    // function definitions needed to compute the DIS vertex
+    // Cross section from splines
     double TotalCrossSection(dataclasses::InteractionRecord const &) const override;
     double TotalCrossSection(siren::dataclasses::ParticleType primary, double energy) const;
     double TotalCrossSectionAllFinalStates(dataclasses::InteractionRecord const &) const override;
@@ -85,35 +128,27 @@ public:
     double DifferentialCrossSection(double energy, double x, double y, double secondary_lepton_mass, double Q2=std::numeric_limits<double>::quiet_NaN()) const;
     double InteractionThreshold(dataclasses::InteractionRecord const &) const override;
 
-    // function definitions needed to compute the hadronization vertex
+    // Fragmentation fraction (from Pythia output statistics)
     double FragmentationFraction(siren::dataclasses::Particle::ParticleType secondary) const;
-    double sample_pdf(double z) const;
-    void compute_cdf();
-    static double getHadronMass(siren::dataclasses::ParticleType hadron_type);
 
-    // used for both processes
+    // Final state sampling via Pythia
     void SampleFinalState(dataclasses::CrossSectionDistributionRecord &, std::shared_ptr<siren::utilities::SIREN_random> random) const override;
+
+    // Signature methods
     std::vector<siren::dataclasses::ParticleType> GetPossibleTargets() const override;
     std::vector<siren::dataclasses::ParticleType> GetPossibleTargetsFromPrimary(siren::dataclasses::ParticleType primary_type) const override;
     std::vector<siren::dataclasses::ParticleType> GetPossiblePrimaries() const override;
     std::vector<dataclasses::InteractionSignature> GetPossibleSignatures() const override;
     std::vector<dataclasses::InteractionSignature> GetPossibleSignaturesFromParents(siren::dataclasses::ParticleType primary_type, siren::dataclasses::ParticleType target_type) const override;
     virtual double FinalStateProbability(dataclasses::InteractionRecord const & record) const override;
+    virtual std::vector<std::string> DensityVariables() const override;
 
-    // other utility functions
-    void LoadFromFile(std::string differential_filename, std::string total_filename);
-    void LoadFromMemory(std::vector<char> & differential_data, std::vector<char> & total_data);
-
-    // utilities for DIS parametrs
-    double GetMinimumQ2() const {return minimum_Q2_;};
-    double GetTargetMass() const {return target_mass_;};
-    int GetInteractionType() const {return interaction_type_;};
-    static double GetLeptonMass(siren::dataclasses::ParticleType lepton_type);
-    static std::map<std::string, int> getIndices(siren::dataclasses::InteractionSignature signature);
-
+    // Getters
+    double GetMinimumQ2() const { return minimum_Q2_; }
+    double GetTargetMass() const { return target_mass_; }
+    int GetInteractionType() const { return interaction_type_; }
 
 public:
-    virtual std::vector<std::string> DensityVariables() const override;
     template<typename Archive>
     void save(Archive & archive, std::uint32_t const version) const {
         if(version == 0) {
@@ -145,9 +180,11 @@ public:
             archive(::cereal::make_nvp("TargetMass", target_mass_));
             archive(::cereal::make_nvp("MinimumQ2", minimum_Q2_));
             archive(::cereal::make_nvp("Unit", unit));
+            archive(::cereal::make_nvp("PdfSet", pdf_set_));
+            archive(::cereal::make_nvp("PythiaDataPath", pythia_data_path_));
             archive(cereal::virtual_base_class<CrossSection>(this));
         } else {
-            throw std::runtime_error("QuarkDISFromSpline only supports version <= 0!");
+            throw std::runtime_error("PythiaDISCrossSection only supports version <= 0!");
         }
     }
     template<typename Archive>
@@ -163,23 +200,22 @@ public:
             archive(::cereal::make_nvp("TargetMass", target_mass_));
             archive(::cereal::make_nvp("MinimumQ2", minimum_Q2_));
             archive(::cereal::make_nvp("Unit", unit));
+            archive(::cereal::make_nvp("PdfSet", pdf_set_));
+            archive(::cereal::make_nvp("PythiaDataPath", pythia_data_path_));
             archive(cereal::virtual_base_class<CrossSection>(this));
             LoadFromMemory(differential_data, total_data);
             InitializeSignatures();
         } else {
-            throw std::runtime_error("QuarkDISFromSpline only supports version <= 0!");
+            throw std::runtime_error("PythiaDISCrossSection only supports version <= 0!");
         }
     }
-private:
-    void ReadParamsFromSplineTable();
-    void InitializeSignatures();
 };
 
 } // namespace interactions
 } // namespace siren
 
-CEREAL_CLASS_VERSION(siren::interactions::QuarkDISFromSpline, 0);
-CEREAL_REGISTER_TYPE(siren::interactions::QuarkDISFromSpline);
-CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::interactions::CrossSection, siren::interactions::QuarkDISFromSpline);
+CEREAL_CLASS_VERSION(siren::interactions::PythiaDISCrossSection, 0);
+CEREAL_REGISTER_TYPE(siren::interactions::PythiaDISCrossSection);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::interactions::CrossSection, siren::interactions::PythiaDISCrossSection);
 
-#endif // SIREN_QuarkDISFromSpline_H
+#endif // SIREN_PythiaDISCrossSection_H

--- a/projects/utilities/private/Random.cxx
+++ b/projects/utilities/private/Random.cxx
@@ -9,13 +9,13 @@ namespace utilities {
     SIREN_random::SIREN_random(void){
         // default to boring seed
         seed   = 1;
-        configuration       = std::default_random_engine(seed);
+        configuration       = std::mt19937_64(seed);
         generator           = std::uniform_real_distribution<double>( 0.0, 1.0);
     }
 
     SIREN_random::SIREN_random( unsigned int _seed ){
         seed = _seed;
-        configuration       = std::default_random_engine(seed);
+        configuration       = std::mt19937_64(seed);
         generator           = std::uniform_real_distribution<double>( 0.0, 1.0);
     }
 
@@ -42,7 +42,7 @@ namespace utilities {
     // reconfigures the generator with a new seed
     void SIREN_random::set_seed( unsigned int new_seed) {
         seed = new_seed;
-        this->configuration = std::default_random_engine(seed);
+        this->configuration = std::mt19937_64(seed);
     }
 
 } // namespace utilities

--- a/projects/utilities/public/SIREN/utilities/Random.h
+++ b/projects/utilities/public/SIREN/utilities/Random.h
@@ -7,7 +7,7 @@
 
 // this implements a class to sample numbers just like in an i3 service
 
-#include <random> // default_random_engine, uniform_real_distribution
+#include <random> // mt19937_64, uniform_real_distribution
 
 #include <cereal/cereal.hpp>
 #include <cereal/archives/json.hpp>
@@ -29,7 +29,7 @@ namespace utilities {
 
             // this naming convention is used to
             double Uniform( double from=0.0, double to=1.0);
-            double PowerLaw(double min, double max, double n); 
+            double PowerLaw(double min, double max, double n);
 
             // in case this is set up without a seed!
             void set_seed(unsigned int new_seed);
@@ -55,7 +55,14 @@ namespace utilities {
 
         private:
             unsigned int seed;
-            std::default_random_engine configuration;
+            // Previously used std::default_random_engine (minstd_rand0 on GCC),
+            // a linear congruential generator with only ~2.1 billion states
+            // (period 2^31-2). With ~500 RNG draws per event and thousands of
+            // seeds each generating 10k events, the birthday paradox causes
+            // frequent internal state collisions across seeds, producing
+            // identical event sequences. Switched to Mersenne Twister
+            // (period 2^19937-1) to eliminate cross-seed duplicates.
+            std::mt19937_64 configuration;
             std::uniform_real_distribution<double> generator;
     };
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ cmake.build-type = "Release"
 
 [tool.scikit-build.cmake.define]
 CMAKE_PREFIX_PATH="/tmp/downloads/local"
-
+CI_INSTALL_PREFIX="/n/holylfs05/LABS/arguelles_delgado_lab/Everyone/pzhelnin/DiMuons/local"
 [tool.cibuildwheel]
 before-all = "bash {project}/tools/wheels/cibw_before_all.sh {project}"
 skip = "pp*"
@@ -25,7 +25,7 @@ environment = { RUNNER_OS="Windows", CI_INSTALL_PREFIX="C:/Users/AppData/Local/T
 repair-wheel-command = "delvewheel repair --add-path $LD_LIBRARY_PATH"
 
 [tool.cibuildwheel.linux]
-environment = { RUNNER_OS="Linux", MAKEFLAGS="-j2", CI_INSTALL_PREFIX="/tmp/downloads/local", CFITSIOROOT="$CI_INSTALL_PREFIX", LD_LIBRARY_PATH="$CI_INSTALL_PREFIX/lib:$CI_INSTALL_PREFIX/lib64:$LD_LIBRARY_PATH" }
+environment = { RUNNER_OS="Linux", MAKEFLAGS="-j2", CI_INSTALL_PREFIX="/n/holylfs05/LABS/arguelles_delgado_lab/Everyone/pzhelnin/DiMuons/local", CFITSIOROOT="$CI_INSTALL_PREFIX", LD_LIBRARY_PATH="$CI_INSTALL_PREFIX/lib:$CI_INSTALL_PREFIX/lib64:$LD_LIBRARY_PATH" }
 repair-wheel-command = "auditwheel repair --exclude photospline -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
### Problem

Different SIREN seeds produce identical events. For example, in a 2000-seed charm simulation with 10,000 events each, ~50% of events are duplicates across seeds — bit-for-bit identical primary energy, direction, vertex, kinematics, and weights.

### Root Cause

`SIREN_random` used `std::default_random_engine`, which on GCC is `minstd_rand0` — a linear congruential generator with only **2^31 - 2 ≈ 2.1 billion** possible internal states. Each event consumes ~500 RNG draws (dominated by the Metropolis-Hastings burnin in `CharmDISFromSpline::SampleFinalState`). With 2,000 seeds × 10,000 events × ~500 draws/event = **10 billion total draws**, the state space is completely saturated.

By the birthday paradox, different seeds inevitably land on the same internal RNG state mid-generation. Once two seeds share a state, every subsequent draw — and therefore every subsequent event — is identical. For example, seed 433 after 447,050 draws reaches the exact internal state that seed 336 starts with, causing 9,113 of their 10,000 events to be identical.

### Fix

Replace `std::default_random_engine` with `std::mt19937_64` (Mersenne Twister, period 2^19937 - 1) in `Random.h` and `Random.cxx`. This eliminates cross-seed state collisions entirely.

### Files Changed

- `projects/utilities/public/SIREN/utilities/Random.h`
- `projects/utilities/private/Random.cxx`